### PR TITLE
Create cycling backup indices with aliasing for zero downtime

### DIFF
--- a/elasticizer/__main__.py
+++ b/elasticizer/__main__.py
@@ -9,15 +9,12 @@ def buildArgParser():
     parser = argparse.ArgumentParser(prog='elasticizer',
                                      description='from DB to Elasticsearch')
 
-    parser.add_argument('--index1', '-i1',  
-                         default=False, required=True, dest='index1',
-                         help='the first Elasticsearch index name that Luigi updates')
-    parser.add_argument('--index2', '-i2',  
-                         default=False, required=True, dest='index2',
-                         help='the second Elasticsearch index name that Luigi updates')
-    parser.add_argument('--alias', '-a',  
-                         default=False, required=True, dest='alias',
-                         help='the Elasticsearch alias name that points to index1 or index2')
+    parser.add_argument('--index', '-i',
+                         default=False, required=True, dest='index',
+                         help='the Elasticsearch index name that Luigi updates')
+    parser.add_argument('--backup', '-b', action='store_true',
+                         default=False, required=False, dest='backup',
+                         help='create new cycling backup indices with -v1 and -v2 appended and aliased with the index arg')
     parser.add_argument('--table', '-t',
                          default=False, required=True, dest='table',
                          help='the Elasticsearch table name that Luigi reads from')
@@ -61,8 +58,16 @@ if __name__ == '__main__':
     parser = buildArgParser()
     cmdline_args = parser.parse_args()
 
+    #decide on indexing
     Indexes = collections.namedtuple('Indexes', ['v1', 'v2', 'alias'])
-    indexes = Indexes(v1=cmdline_args.index1, v2=cmdline_args.index2, alias=cmdline_args.alias)
+    if cmdline_args.backup:
+        indexes = Indexes(v1=cmdline_args.index+'-v1',
+                          v2=cmdline_args.index+'-v2',
+                          alias=cmdline_args.index)
+    else:
+        indexes = Indexes(v1=cmdline_args.index,
+                          v2=None,
+                          alias=None)
     # get the end class
     task = Load(indexes=indexes, 
                 mapping_file=cmdline_args.mapping_file,

--- a/elasticizer/__main__.py
+++ b/elasticizer/__main__.py
@@ -3,14 +3,21 @@ import luigi
 import os
 import random
 from elasticizer import Load
+import collections
 
 def buildArgParser():
     parser = argparse.ArgumentParser(prog='elasticizer',
                                      description='from DB to Elasticsearch')
 
-    parser.add_argument('--index', '-i',  
-                         default=False, required=True, dest='index',
-                         help='the Elasticsearch index name that Luigi updates')
+    parser.add_argument('--index1', '-i1',  
+                         default=False, required=True, dest='index1',
+                         help='the first Elasticsearch index name that Luigi updates')
+    parser.add_argument('--index2', '-i2',  
+                         default=False, required=True, dest='index2',
+                         help='the second Elasticsearch index name that Luigi updates')
+    parser.add_argument('--alias', '-a',  
+                         default=False, required=True, dest='alias',
+                         help='the Elasticsearch alias name that points to index1 or index2')
     parser.add_argument('--table', '-t',
                          default=False, required=True, dest='table',
                          help='the Elasticsearch table name that Luigi reads from')
@@ -45,7 +52,7 @@ def clear(last):
             else:
                 if task.output().exists():
                     try :
-                      task.output().remove()
+                        task.output().remove()
                     except:
                         pass    
 
@@ -54,8 +61,10 @@ if __name__ == '__main__':
     parser = buildArgParser()
     cmdline_args = parser.parse_args()
 
+    Indexes = collections.namedtuple('Indexes', ['v1', 'v2', 'alias'])
+    indexes = Indexes(v1=cmdline_args.index1, v2=cmdline_args.index2, alias=cmdline_args.alias)
     # get the end class
-    task = Load(index=cmdline_args.index, 
+    task = Load(indexes=indexes, 
                 mapping_file=cmdline_args.mapping_file,
                 settings_file=cmdline_args.settings_file,
                 docs_file=cmdline_args.docs_file,

--- a/elasticizer/__main__.py
+++ b/elasticizer/__main__.py
@@ -10,13 +10,13 @@ def buildArgParser():
                                      description='from DB to Elasticsearch')
 
     parser.add_argument('--index', '-i',
-                         default=False, required=True, dest='index',
+                         required=True, dest='index',
                          help='the Elasticsearch index name that Luigi updates')
-    parser.add_argument('--backup', '-b', action='store_true',
-                         default=False, required=False, dest='backup',
-                         help='create new cycling backup indices with -v1 and -v2 appended and aliased with the index arg')
+    parser.add_argument('--backup_count', '-b', 
+                         default=0, type=backup_type, dest='backup_count',
+                         help='create new cycling indices (*-v1 -v2... -vN), with current aliased by the index arg')
     parser.add_argument('--table', '-t',
-                         default=False, required=True, dest='table',
+                         required=True, dest='table',
                          help='the Elasticsearch table name that Luigi reads from')
     parser.add_argument('--mapping_file', '-m',  metavar='mapping file',
                          default='mappings.json', dest='mapping_file',
@@ -33,8 +33,13 @@ def buildArgParser():
     parser.add_argument('--clear', action='store_true', 
                         default=False, dest='clear', 
                         help='clear all targets')
-
     return parser
+
+def backup_type(x):
+    x = int(x)
+    if x < 1:
+        raise argparse.ArgumentTypeError("Minimum backup count is 0 for no backups")
+    return x
 
 def clear(last):
     visited, queue = set(), [last]
@@ -53,21 +58,28 @@ def clear(last):
                     except:
                         pass    
 
+def label_indices(n_versions, index_name):
+    #create a version and version name for each 
+    labels = [''] * (n_versions+1)
+    index_names = [''] * (n_versions+1)
+    for i in range(n_versions):
+        labels[i] = 'v' + str(i+1)
+        index_names[i] = index_name + '-' + labels[i]
+   #if no backups, don't create an alias 
+    labels[n_versions] = 'alias'
+    if n_versions > 1:
+        index_names[n_versions] = index_name
+    #assemble into a named tuple
+    Indexes = collections.namedtuple('Indexes', labels)
+    return Indexes(*index_names)
+
 if __name__ == '__main__':
     # get the arguments from the command line
     parser = buildArgParser()
     cmdline_args = parser.parse_args()
 
-    #decide on indexing
-    Indexes = collections.namedtuple('Indexes', ['v1', 'v2', 'alias'])
-    if cmdline_args.backup:
-        indexes = Indexes(v1=cmdline_args.index+'-v1',
-                          v2=cmdline_args.index+'-v2',
-                          alias=cmdline_args.index)
-    else:
-        indexes = Indexes(v1=cmdline_args.index,
-                          v2=None,
-                          alias=None)
+    #get a named tuple of indexes v1...vN
+    indexes = label_indices(cmdline_args.backup_count+1, cmdline_args.index)
     # get the end class
     task = Load(indexes=indexes, 
                 mapping_file=cmdline_args.mapping_file,

--- a/elasticizer/__main__.py
+++ b/elasticizer/__main__.py
@@ -14,7 +14,7 @@ def buildArgParser():
                          help='the Elasticsearch index name that Luigi updates')
     parser.add_argument('--backup_count', '-b', 
                          default=0, type=backup_type, dest='backup_count',
-                         help='create new cycling indices (*-v1 -v2... -vN), with current aliased by the index arg')
+                         help='number of back up indices: creates cycling indices (*-v1 -v2... -vN), with current aliased by the index arg')
     parser.add_argument('--table', '-t',
                          required=True, dest='table',
                          help='the Elasticsearch table name that Luigi reads from')


### PR DESCRIPTION
I'm not very happy with the API as-is. Asking for index1, index2 and alias seems like over-kill. 

I was thinking about refactoring to just ask for a `required` `--index-alias=` argument. By default that could be used as the old index argument (and also create an alias by the same name. Then, if there's a -b --backup, the code would use `index_alias` for the alias and cycles between some pre-defined `index_alias+'-v1'` and  `index_alias+'-v2'`. Thoughts?
