### PR TITLE
Allow a list of copyto fields

### DIFF
--- a/elasticizer/pipelines/extract_postgres.py
+++ b/elasticizer/pipelines/extract_postgres.py
@@ -52,7 +52,10 @@ class Format(luigi.Task):
             mapping_json = json.load(fp, object_pairs_hook=collections.OrderedDict)
             fields = mapping_json['properties'].keys()
             # Automatically remove copy_to fields because they aren't expected from the input
-            copy_targets = set([i.get('copy_to','') for i in mapping_json['properties'].values()])
+            #pull out all the values for the key "copy_to"
+            l = [i.get('copy_to','') for i in mapping_json['properties'].values()]
+            # if copy_to is a list, then flatten it out in the set, else just take individual value
+            copy_targets = set([item if isinstance(sublist, list) else sublist for sublist in l for item in sublist])
             for ct in copy_targets:
                 if ct:
                     fields.remove(ct)


### PR DESCRIPTION
The original code only allow 1 field as the value to `copyto`, this change allow the use of a list as a value of `copyto` in addition to just 1 field.
## Changes:
- Supported the use of list as a value of `copyto` 
## Reviews:
- @sleitner @JeffreyMFarley @sephcoster 
